### PR TITLE
Created multistage alpine based build

### DIFF
--- a/conf/app.prod.conf
+++ b/conf/app.prod.conf
@@ -1,0 +1,7 @@
+#   appname = captureorderfd
+appname = captureorderack
+httpport = 8080
+runmode = prod
+autorender = false
+copyrequestbody = true
+EnableDocs = true

--- a/main.go
+++ b/main.go
@@ -8,9 +8,7 @@ import (
 )
 
 func main() {
-	if beego.BConfig.RunMode == "dev" {
-		beego.BConfig.WebConfig.DirectoryIndex = true
-		beego.BConfig.WebConfig.StaticDir["/swagger"] = "swagger"
-	}
+	beego.BConfig.WebConfig.DirectoryIndex = true
+	beego.BConfig.WebConfig.StaticDir["/swagger"] = "swagger"
 	beego.Run()
 }


### PR DESCRIPTION
Hi, 

This moves to a multistage build were only the app config, binary and swagger files are needed in the final alpine build.

Work Notes:
- Move Beego to using "prod" runmode
- Move to using alphine go image
- Copy binary, app.conf and swagger files from buildEnv to finalstage alpine image
- Add EXPOSE tag to highlight port serving on
- Update main.go to still serve swagger when in prod mode
